### PR TITLE
Correct pydata talk links

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,11 +224,11 @@ interfaces.</P>
 <UL>
 <LI><P>
 H. Zafeiropoulos - 
-<A href="https://global.pydata.org/talks/geometric-and-statistical-methods-in-systems-biology-the-case-of-metabolic-networks">Geometric and statistical methods in systems biology: the case of metabolic networks</A>, PyData Global, 2020. 
+<A href="https://global.pydata.org/talks/166">Geometric and statistical methods in systems biology: the case of metabolic networks</A>, PyData Global, 2020. 
 </P></LI>
 <LI><P>
 M. Papachristou - 
-<A href="https://global.pydata.org/talks/sampling-from-truncated-high-dimensional-logconcave-densities-with-volesti-geomscale-project">Sampling from (truncated) high-dimensional logconcave densities with VolEsti</A>, PyData Global, 2020. 
+<A href="https://global.pydata.org/talks/144">Sampling from (truncated) high-dimensional logconcave densities with VolEsti</A>, PyData Global, 2020. 
 </P></LI>
 <LI><P>
 A. Chalkis - 


### PR DESCRIPTION
This PR contains corrections to the broken pydata global 2020 talk links. 